### PR TITLE
Update GitHub Actions to v4

### DIFF
--- a/.github/workflows/main_chn-sydney.yml
+++ b/.github/workflows/main_chn-sydney.yml
@@ -28,7 +28,7 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: .
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 

--- a/.github/workflows/main_sydney-ikechan8370.yml
+++ b/.github/workflows/main_sydney-ikechan8370.yml
@@ -28,7 +28,7 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: .
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 

--- a/.github/workflows/main_sydneyhk.yml
+++ b/.github/workflows/main_sydneyhk.yml
@@ -28,7 +28,7 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: .
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 

--- a/.github/workflows/main_sydneyjp.yml
+++ b/.github/workflows/main_sydneyjp.yml
@@ -29,7 +29,7 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: .
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 


### PR DESCRIPTION
Update GitHub Actions to use v4 of `actions/upload-artifact` and `actions/download-artifact`.

* **.github/workflows/main_chn-sydney.yml**
  - Update `actions/upload-artifact` to use `v4`
  - Update `actions/download-artifact` to use `v4`

* **.github/workflows/main_sydney-ikechan8370.yml**
  - Update `actions/upload-artifact` to use `v4`
  - Update `actions/download-artifact` to use `v4`

* **.github/workflows/main_sydneyhk.yml**
  - Update `actions/upload-artifact` to use `v4`
  - Update `actions/download-artifact` to use `v4`

* **.github/workflows/main_sydneyjp.yml**
  - Update `actions/upload-artifact` to use `v4`
  - Update `actions/download-artifact` to use `v4`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ikechan8370/sydney-ws-proxy/pull/3?shareId=be37e0b3-1bab-4c5f-b2ea-68d5ed8dee6d).